### PR TITLE
Fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Ignore when calculating language stats
+src/gui/res/fonts/* linguist-vendored
+
+
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,7 @@ src/gui/res/fonts/* linguist-vendored
 #
 # Merging from the command prompt will add diff markers to the files if there
 # are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following 
+# the diff markers are never inserted). Diff markers may cause the following
 # file extensions to fail to load in VS. An alternative would be to treat
 # these files as binary and thus will always conflict and require user
 # intervention with every merge. To do so, just uncomment the entries below
@@ -50,9 +50,9 @@ src/gui/res/fonts/* linguist-vendored
 
 ###############################################################################
 # diff behavior for common document formats
-# 
+#
 # Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the 
+# is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
 #*.doc   diff=astextplain


### PR DESCRIPTION
Ignore the folder containing Icon.js. This should take the 38.3% Javascript out of our language stats.

Reference:
- https://github.com/github/linguist/issues/137
- https://github.com/github/linguist#overrides
